### PR TITLE
add signaling_client_fetch

### DIFF
--- a/src/include/kvs/webrtc_client.h
+++ b/src/include/kvs/webrtc_client.h
@@ -1627,6 +1627,25 @@ PUBLIC_API STATUS signaling_client_getIceConfigInfoCount(SIGNALING_CLIENT_HANDLE
 PUBLIC_API STATUS signaling_client_getIceConfigInfo(SIGNALING_CLIENT_HANDLE, UINT32, PIceConfigInfo*);
 
 /**
+ * @brief Shutdown signaling client.
+ *
+ * @param[in] SIGNALING_CLIENT_HANDLE Signaling client handle
+ *
+ * @return STATUS code of the execution. STATUS_SUCCESS on successs
+ */
+PUBLIC_API STATUS signaling_client_shutdown(SIGNALING_CLIENT_HANDLE);
+
+/**
+ * @brief Fetches all assets needed to ready the state machine before attempting to connect.
+ *        Can also be used to reallocate missing / expired assets before reconnecting.
+ *
+ * @param[in] SIGNALING_CLIENT_HANDLE Signaling client handle
+ *
+ * @return STATUS code of the execution. STATUS_SUCCESS on successs
+ */
+PUBLIC_API STATUS signaling_client_fetch(SIGNALING_CLIENT_HANDLE);
+
+/**
  * @brief Connects the signaling client to the web socket in order to send/receive messages.
  *
  * NOTE: The call will succeed only when the signaling client is in a ready state.

--- a/src/source/signaling/client.c
+++ b/src/source/signaling/client.c
@@ -94,6 +94,44 @@ CleanUp:
     return retStatus;
 }
 
+STATUS signaling_client_shutdown(SIGNALING_CLIENT_HANDLE signalingClientHandle)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PSignalingClient pSignalingClient = FROM_SIGNALING_CLIENT_HANDLE(signalingClientHandle);
+
+    CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
+
+    DLOGI("Signaling Client shutdown");
+
+    ATOMIC_STORE_BOOL(&pSignalingClient->shutdown, TRUE);
+
+CleanUp:
+
+    SIGNALING_UPDATE_ERROR_COUNT(pSignalingClient, retStatus);
+    LEAVES();
+    return retStatus;
+}
+
+STATUS signaling_client_fetch(SIGNALING_CLIENT_HANDLE signalingClientHandle)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PSignalingClient pSignalingClient = FROM_SIGNALING_CLIENT_HANDLE(signalingClientHandle);
+
+    CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
+
+    DLOGI("Signaling Client Fetch Sync");
+
+    CHK_STATUS(signaling_fetch(pSignalingClient));
+
+CleanUp:
+
+    SIGNALING_UPDATE_ERROR_COUNT(pSignalingClient, retStatus);
+    LEAVES();
+    return retStatus;
+}
+
 STATUS signaling_client_connect(SIGNALING_CLIENT_HANDLE signalingClientHandle)
 {
     ENTERS();

--- a/src/source/signaling/signaling.h
+++ b/src/source/signaling/signaling.h
@@ -394,6 +394,14 @@ STATUS signaling_create(PSignalingClientInfoInternal pClientInfo, PChannelInfo p
  */
 STATUS signaling_free(PSignalingClient* ppSignalingClient);
 /**
+ * @brief bring signaling client state to READY.
+ *
+ * @param[in] pSignalingClient the context of the signaling client.
+ *
+ * @return STATUS status of execution.
+ */
+STATUS signaling_fetch(PSignalingClient pSignalingClient);
+/**
  * @brief connect signaling client with the specific signaling channel.
  *
  * @param[in] pSignalingClient the context of the signaling client.


### PR DESCRIPTION
add signaling_client_shutdown
can shutdown signaling client after create signaling state machine

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
